### PR TITLE
Add support for KEYS command

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,4 +163,11 @@ datastore.Datastore.prototype.get = thenify(function (key, cb) {
   });
 });
 
+datastore.Datastore.prototype.keys = thenify(function (key, cb) {
+  var self = this;
+  self.client.multi().keys('/ds/' + self.root + "/" + key, function(err, replies){
+    return cb(err, replies);
+  });
+});
+
 module['exports'] = datastore;


### PR DESCRIPTION
Use [`keys`](http://redis.io/commands/KEYS) method in order to return list of keys defined by a pattern such as `key/foo/*` or `key/*`. bigcompany/hook.io#220
